### PR TITLE
Treat undef param value as empty string

### DIFF
--- a/lib/URI/Query/FromHash.pm
+++ b/lib/URI/Query/FromHash.pm
@@ -25,7 +25,7 @@ sub hash2query(+%) {
 
         for ( ref $v ? @$v : $v ) {
             # Avoid modifying the original.
-            my $v = $_;
+            my $v = $_ // '';
 
             $v =~ s|([;/?:@&=+,\$\[\]%])|$escapes{$1}|g;
             $v =~ y| |+|;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 12;
 use URI::Query::FromHash;
 
 my %args = ( a => 'b' );
@@ -22,3 +22,7 @@ is hash2query( { a => 'b', c => [] } ), 'a=b',
 
 is hash2query( { a => [ 11..15 ] } ), 'a=11&a=12&a=13&a=14&a=15',
     'hash2query { a => [ 11..15 ] }';
+
+is hash2query( { a => undef } ), 'a=', 'hash2query( { a => undef }';
+is hash2query( { a => [1, undef, 2] } ), 'a=1&a=&a=2',
+    'hash2query( { a => [1, undef, 2] }';


### PR DESCRIPTION
This commit amounts to a change in behaviour where undef query param values get treated as empty strings. This avoids the uninit warning which would normally occur and follows the precedent set by the URI module:

perl -MURI -E 'my $uri = URI->new("http://localhost/foo"); $uri->query_form(bar => [1, undef, 2], baz => undef); say $uri'
http://localhost/foo?bar=1&bar=&bar=2&baz=